### PR TITLE
Bumped version of base

### DIFF
--- a/bitcoin-scripting.cabal
+++ b/bitcoin-scripting.cabal
@@ -28,7 +28,7 @@ common base
     -Wno-unused-do-bind
     -funbox-strict-fields
   build-depends:
-      base >=4.12 && <4.16
+      base >=4.12 && <5
     , bytestring >=0.10 && <0.12
     , cereal ^>=0.5
     , haskoin-core ^>=0.21


### PR DESCRIPTION
Increased the upper bound on permitted versions of `base` to allow all versions of base 4.x