### PR TITLE
Added fourmolu.yaml, upgraded bitcoin-scripting to use haskoin-core-1.0

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,4 @@
 import Distribution.Simple
+
+
 main = defaultMain

--- a/bitcoin-scripting.cabal
+++ b/bitcoin-scripting.cabal
@@ -31,7 +31,7 @@ common base
       base >=4.12 && <5
     , bytestring >=0.10 && <0.12
     , cereal ^>=0.5
-    , haskoin-core ^>=0.21
+    , haskoin-core >=1.0.0 && <1.2
     , text >=1.2 && <2.1
     , unordered-containers ^>=0.2
 
@@ -85,7 +85,6 @@ test-suite bitcoin-scripting-tests
 
   build-depends:
       bitcoin-scripting
-    , bytes ^>=0.17
     , tasty >=1.0 && <1.5
     , tasty-hunit >=0.9 && <0.11
     , tasty-quickcheck >=0.8.1 && <0.11

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,24 @@
+indentation: 4
+comma-style: leading # for lists, tuples etc. - can also be 'trailing'
+record-brace-space: false # rec {x = 1} vs. rec{x = 1}
+indent-wheres: false # 'false' means save space by only half-indenting the 'where' keyword
+import-export-style: diff-friendly # choices: leading, trailing, diff-friendly
+respectful: true # don't be too opinionated about newlines etc.
+haddock-style: single-line # '--' vs. '{-'
+newlines-between-decls: 2
+single-constraint-parens: never # defaults to 'always', could also be 'auto' (ignore), and 'never'
+single-deriving-parens: never # choices: auto, always, never
+column-limit: 120 # limit columns to 120 characters, as per our style guide
+let-style: inline # choices: auto, inline, newline, mixed
+fixities:
+  - infixr 0  $, $!
+  - infixl 1  >>, >>=, &
+  - infixr 1  =<<
+  - infixl 3 <?>, @?=
+  - infixl 4 <*>, <*, *>, <**>, <$
+  - infixr 4 ?~
+  - infixr 5  ++
+  - infixr 5 :|
+  - infixr 6 <>
+  - infixl 8 .:, .:?, .=, .=?
+  - infixr 9  .

--- a/src/Language/Bitcoin/Miniscript.hs
+++ b/src/Language/Bitcoin/Miniscript.hs
@@ -1,9 +1,8 @@
-{- |
- Module: Language.Bitcoin.Miniscript
-
- Haskell embedding of miniscript.  See http://bitcoin.sipa.be/miniscript/ for
- details.  Much of the documentation below is taken from this site.
--}
+-- |
+--  Module: Language.Bitcoin.Miniscript
+--
+--  Haskell embedding of miniscript.  See http://bitcoin.sipa.be/miniscript/ for
+--  details.  Much of the documentation below is taken from this site.
 module Language.Bitcoin.Miniscript (
     -- * Syntax tree
     Value (..),
@@ -51,3 +50,4 @@ import Language.Bitcoin.Miniscript.Parser
 import Language.Bitcoin.Miniscript.Syntax
 import Language.Bitcoin.Miniscript.Text
 import Language.Bitcoin.Miniscript.Types
+

--- a/src/Language/Bitcoin/Miniscript/Compiler.hs
+++ b/src/Language/Bitcoin/Miniscript/Compiler.hs
@@ -41,6 +41,7 @@ import Language.Bitcoin.Script.Descriptors.Syntax (KeyDescriptor, keyBytes)
 import Language.Bitcoin.Script.Utils (pushNumber)
 import Language.Bitcoin.Utils (requiredContextValue)
 
+
 data CompilerError
     = FreeVariable Text
     | CompilerError Miniscript
@@ -49,7 +50,9 @@ data CompilerError
     | AbstractKey KeyDescriptor
     deriving (Eq, Show)
 
+
 instance Exception CompilerError
+
 
 -- | Type check and compile a miniscript
 compile :: Miniscript -> Either CompilerError Script
@@ -57,17 +60,22 @@ compile script = do
     void . first TypeError $ typeCheckMiniscript mempty script
     compileOnly script
 
+
 -- | Compile a miniscript without type checking
 compileOnly :: Miniscript -> Either CompilerError Script
 compileOnly = fmap Script . runExcept . (`runReaderT` Context mempty) . compileOpsInContext
 
+
 newtype Context = Context {unContext :: Map Text (Context, Miniscript)}
+
 
 addClosure :: Text -> Miniscript -> Context -> Context
 addClosure n e c = Context . Map.insert n (c, e) $ unContext c
 
+
 requiredScript :: Text -> ReaderT Context (Except CompilerError) (Context, Miniscript)
 requiredScript name = requiredContextValue unContext (FreeVariable name) name
+
 
 compileOpsInContext :: Miniscript -> ReaderT Context (Except CompilerError) [ScriptOp]
 compileOpsInContext = \case
@@ -189,6 +197,7 @@ compileOpsInContext = \case
     requiredBytes = required $ \case
         Bytes b -> return b
         e -> typeError e
+
 
 unsnoc :: [a] -> ([a], a)
 unsnoc [] = error "unsnoc: empty list"

--- a/src/Language/Bitcoin/Miniscript/Compiler.hs
+++ b/src/Language/Bitcoin/Miniscript/Compiler.hs
@@ -28,7 +28,6 @@ import Haskoin.Script (
     ScriptOp (..),
     opPushData,
  )
-
 import Language.Bitcoin.Miniscript.Syntax (
     Miniscript (..),
     Value (..),

--- a/src/Language/Bitcoin/Miniscript/Parser.hs
+++ b/src/Language/Bitcoin/Miniscript/Parser.hs
@@ -27,14 +27,21 @@ import Language.Bitcoin.Utils (
     spacePadded,
  )
 
+
 parseMiniscript :: Network -> Text -> Either String Miniscript
 parseMiniscript net = A.parseOnly $ miniscriptParser net
+
 
 miniscriptParser :: Network -> Parser Miniscript
 miniscriptParser net = annotP expression <|> expression
   where
     expression =
-        keyP <|> keyCP <|> keyHP <|> keyHCP <|> olderP <|> afterP
+        keyP
+            <|> keyCP
+            <|> keyHP
+            <|> keyHCP
+            <|> olderP
+            <|> afterP
             <|> sha256P
             <|> ripemd160P
             <|> hash256P
@@ -80,7 +87,8 @@ miniscriptParser net = annotP expression <|> expression
 
     andOrP =
         application "andor" $
-            AndOr <$> mp
+            AndOr
+                <$> mp
                 <*> comma mp
                 <*> comma mp
 
@@ -96,7 +104,8 @@ miniscriptParser net = annotP expression <|> expression
 
     letP = do
         void $ A.string "let"
-        Let <$> spacePadded varIdentP
+        Let
+            <$> spacePadded varIdentP
             <*> (A.char '=' >> spacePadded mp)
             <*> (A.string "in" >> spacePadded mp)
 

--- a/src/Language/Bitcoin/Miniscript/Parser.hs
+++ b/src/Language/Bitcoin/Miniscript/Parser.hs
@@ -11,8 +11,7 @@ import Control.Monad (void)
 import Data.Attoparsec.Text (Parser)
 import qualified Data.Attoparsec.Text as A
 import Data.Text (Text, pack)
-import Haskoin.Constants (Network)
-
+import Haskoin.Network (Network)
 import Language.Bitcoin.Miniscript.Syntax (
     Miniscript (..),
     Value (..),

--- a/src/Language/Bitcoin/Miniscript/Syntax.hs
+++ b/src/Language/Bitcoin/Miniscript/Syntax.hs
@@ -28,7 +28,6 @@ module Language.Bitcoin.Miniscript.Syntax (
 import Data.ByteString (ByteString)
 import Data.Foldable (foldr')
 import Data.Text (Text)
-
 import Language.Bitcoin.Script.Descriptors.Syntax (KeyDescriptor)
 
 

--- a/src/Language/Bitcoin/Miniscript/Syntax.hs
+++ b/src/Language/Bitcoin/Miniscript/Syntax.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
 
-{- |
- Module: Language.Bitcoin.Miniscript.Syntax
-
- Haskell embedding of miniscript.  See http://bitcoin.sipa.be/miniscript/ for
- details.  Much of the documentation below is taken from this site.
--}
+-- |
+--  Module: Language.Bitcoin.Miniscript.Syntax
+--
+--  Haskell embedding of miniscript.  See http://bitcoin.sipa.be/miniscript/ for
+--  details.  Much of the documentation below is taken from this site.
 module Language.Bitcoin.Miniscript.Syntax (
     Value (..),
     var,
@@ -32,14 +31,18 @@ import Data.Text (Text)
 
 import Language.Bitcoin.Script.Descriptors.Syntax (KeyDescriptor)
 
+
 data Value a = Variable Text | Lit a
     deriving (Eq, Show, Ord)
+
 
 var :: Text -> Value a
 var = Variable
 
+
 literal :: a -> Value a
 literal = Lit
+
 
 -- | The Miniscript AST with the addition of key descriptors and let bindings
 data Miniscript
@@ -75,45 +78,59 @@ data Miniscript
     | AnnN Miniscript
     deriving (Eq, Show)
 
+
 -- | Check a key
 key :: KeyDescriptor -> Miniscript
 key = AnnC . Key . literal
+
 
 -- | Check a key hash
 keyH :: KeyDescriptor -> Miniscript
 keyH = AnnC . KeyH . literal
 
+
 older :: Int -> Miniscript
 older = Older . literal
+
 
 after :: Int -> Miniscript
 after = After . literal
 
+
 sha256 :: ByteString -> Miniscript
 sha256 = Sha256 . literal
+
 
 ripemd160 :: ByteString -> Miniscript
 ripemd160 = Ripemd160 . literal
 
+
 hash256 :: ByteString -> Miniscript
 hash256 = Hash256 . literal
+
 
 hash160 :: ByteString -> Miniscript
 hash160 = Hash160 . literal
 
+
 thresh :: Int -> Miniscript -> [Miniscript] -> Miniscript
 thresh k = Thresh (Lit k)
+
 
 multi :: Int -> [KeyDescriptor] -> Miniscript
 multi k ks = Multi (literal k) $ literal <$> ks
 
+
 let_ :: [(Text, Miniscript)] -> Miniscript -> Miniscript
 let_ = flip . foldr' $ uncurry Let
+
 
 class MiniscriptAnnotation a where
     (.:) :: a -> Miniscript -> Miniscript
 
+
 data Annotation = A | S | C | D | V | J | N | T | L | U deriving (Eq, Show, Ord, Enum)
+
 
 instance MiniscriptAnnotation Annotation where
     (.:) = \case
@@ -127,6 +144,7 @@ instance MiniscriptAnnotation Annotation where
         T -> (`AndV` Boolean True)
         L -> OrI $ Boolean True
         U -> (`OrI` Boolean False)
+
 
 instance MiniscriptAnnotation a => MiniscriptAnnotation [a] where
     (.:) = flip $ foldr' (.:)

--- a/src/Language/Bitcoin/Miniscript/Text.hs
+++ b/src/Language/Bitcoin/Miniscript/Text.hs
@@ -8,9 +8,8 @@ module Language.Bitcoin.Miniscript.Text (
 
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Haskoin.Constants (Network)
+import Haskoin.Network (Network)
 import Haskoin.Util (encodeHex)
-
 import Language.Bitcoin.Miniscript.Syntax (
     Miniscript (..),
     Value (..),

--- a/src/Language/Bitcoin/Miniscript/Text.hs
+++ b/src/Language/Bitcoin/Miniscript/Text.hs
@@ -18,6 +18,7 @@ import Language.Bitcoin.Miniscript.Syntax (
 import Language.Bitcoin.Script.Descriptors.Text (keyDescriptorToText)
 import Language.Bitcoin.Utils (applicationText, showText)
 
+
 miniscriptToText :: Network -> Miniscript -> Text
 miniscriptToText net = \case
     Var n -> n

--- a/src/Language/Bitcoin/Miniscript/Types.hs
+++ b/src/Language/Bitcoin/Miniscript/Types.hs
@@ -29,7 +29,9 @@ import Language.Bitcoin.Miniscript.Syntax (
  )
 import Language.Bitcoin.Utils (requiredContextValue)
 
+
 {-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+
 
 data BaseType
     = -- | Base expression
@@ -48,26 +50,29 @@ data BaseType
       TypeKeyDesc
     deriving (Eq, Show)
 
+
 notW :: BaseType -> Bool
 notW = (/= TypeW)
 
+
 -- | Type modifications that imply additional properties of the expression
 data ModField = ModField
-    { -- | Consumes exactly 0 stack elements
-      modZ :: Bool
-    , -- | One-arg: this expression always consumes exactly 1 stack element.
-      modO :: Bool
-    , -- | Nonzero: this expression always consumes at least 1 stack element, no
-      -- satisfaction for this expression requires the top input stack element to
-      -- be zero.
-      modN :: Bool
-    , -- | Dissatisfiable: a dissatisfaction for this expression can
-      -- unconditionally be constructed.
-      modD :: Bool
-    , -- | Unit: when satisfied put exactly 1 on the stack
-      modU :: Bool
+    { modZ :: Bool
+    -- ^ Consumes exactly 0 stack elements
+    , modO :: Bool
+    -- ^ One-arg: this expression always consumes exactly 1 stack element.
+    , modN :: Bool
+    -- ^ Nonzero: this expression always consumes at least 1 stack element, no
+    -- satisfaction for this expression requires the top input stack element to
+    -- be zero.
+    , modD :: Bool
+    -- ^ Dissatisfiable: a dissatisfaction for this expression can
+    -- unconditionally be constructed.
+    , modU :: Bool
+    -- ^ Unit: when satisfied put exactly 1 on the stack
     }
     deriving (Eq, Show)
+
 
 data MiniscriptType = MiniscriptType
     { baseType :: BaseType
@@ -75,8 +80,10 @@ data MiniscriptType = MiniscriptType
     }
     deriving (Eq, Show)
 
+
 emptyModField :: ModField
 emptyModField = ModField False False False False False
+
 
 boolType :: Bool -> MiniscriptType
 boolType = MiniscriptType TypeB . bool falseMods trueMods
@@ -84,14 +91,18 @@ boolType = MiniscriptType TypeB . bool falseMods trueMods
     trueMods = emptyModField{modZ = True, modU = True}
     falseMods = emptyModField{modZ = True, modU = True, modD = True}
 
+
 numberType :: MiniscriptType
 numberType = MiniscriptType TypeNumber emptyModField
+
 
 bytesType :: MiniscriptType
 bytesType = MiniscriptType TypeBytes emptyModField
 
+
 keyDescriptorType :: MiniscriptType
 keyDescriptorType = MiniscriptType TypeKeyDesc emptyModField
+
 
 data MiniscriptTypeError
     = MiniscriptTypeError Miniscript
@@ -100,10 +111,13 @@ data MiniscriptTypeError
       WrongVariableType Text BaseType MiniscriptType
     deriving (Eq, Show)
 
+
 type TypeCheckM a = ReaderT (Map Text MiniscriptType) (Except MiniscriptTypeError) a
+
 
 requiredVarType :: Text -> TypeCheckM MiniscriptType
 requiredVarType name = requiredContextValue id (UntypedVariable name) name
+
 
 -- | Check that a miniscript expression is well-typed.
 typeCheckMiniscript ::
@@ -112,6 +126,7 @@ typeCheckMiniscript ::
     Miniscript ->
     Either MiniscriptTypeError MiniscriptType
 typeCheckMiniscript context = runExcept . (`runReaderT` context) . typeCheckInContext
+
 
 typeCheckInContext :: Miniscript -> TypeCheckM MiniscriptType
 typeCheckInContext = \case

--- a/src/Language/Bitcoin/Miniscript/Types.hs
+++ b/src/Language/Bitcoin/Miniscript/Types.hs
@@ -22,7 +22,6 @@ import Data.Bool (bool)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
-
 import Language.Bitcoin.Miniscript.Syntax (
     Miniscript (..),
     Value (..),
@@ -278,7 +277,7 @@ typeCheckInContext = \case
             count f = sum . fmap (bool 0 1 . f)
             isDU m = modD m && modU m
 
-        if baseType tx == TypeB && all (== TypeW) (baseType <$> tys) && all isDU allMods
+        if baseType tx == TypeB && all ((== TypeW) . baseType) tys && all isDU allMods
             then
                 exprType
                     TypeB

--- a/src/Language/Bitcoin/Script/Descriptors.hs
+++ b/src/Language/Bitcoin/Script/Descriptors.hs
@@ -1,6 +1,5 @@
-{- | A library for working with bitcoin script descriptors. Documentation taken
- from <https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md>.
--}
+-- | A library for working with bitcoin script descriptors. Documentation taken
+--  from <https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md>.
 module Language.Bitcoin.Script.Descriptors (
     -- * Descriptors
     OutputDescriptor (..),
@@ -60,8 +59,9 @@ module Language.Bitcoin.Script.Descriptors (
     validDescriptorChecksum,
 ) where
 
+import Language.Bitcoin.Script.Descriptors.Checksum
 import Language.Bitcoin.Script.Descriptors.Parser
 import Language.Bitcoin.Script.Descriptors.Syntax
 import Language.Bitcoin.Script.Descriptors.Text
 import Language.Bitcoin.Script.Descriptors.Utils
-import Language.Bitcoin.Script.Descriptors.Checksum
+

--- a/src/Language/Bitcoin/Script/Descriptors/Checksum.hs
+++ b/src/Language/Bitcoin/Script/Descriptors/Checksum.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE ParallelListComp #-}
 
 module Language.Bitcoin.Script.Descriptors.Checksum (
-  validDescriptorChecksum,
-  descriptorChecksum,
+    validDescriptorChecksum,
+    descriptorChecksum,
 ) where
 
 import Data.Bifunctor (first)
@@ -17,84 +17,93 @@ import qualified Data.Text as Text
 import Data.Vector.Unboxed (Vector)
 import qualified Data.Vector.Unboxed as Vector
 
-{- | Test whether the textual representation of an output descriptor has the
- given checksum.
--}
+
+-- | Test whether the textual representation of an output descriptor has the
+--  given checksum.
 validDescriptorChecksum :: Text -> Text -> Bool
 validDescriptorChecksum desc checksum =
-  case mapM (charsetFind checksumCharset) (Text.unpack checksum) of
-    Nothing -> False
-    Just checkSymbols ->
-      1 == polymodChecksum (expandChecksum desc <> checkSymbols)
+    case mapM (charsetFind checksumCharset) (Text.unpack checksum) of
+        Nothing -> False
+        Just checkSymbols ->
+            1 == polymodChecksum (expandChecksum desc <> checkSymbols)
 
-{- | Compute the checksum of the textual representation of an output descriptor
- if possible.
--}
+
+-- | Compute the checksum of the textual representation of an output descriptor
+--  if possible.
 descriptorChecksum :: Text -> Maybe Text
 descriptorChecksum desc = Text.pack <$> sequenceA checksumChars
- where
-  checksumChars = [checksumCharset `charsetGet` charsetIndex i | i <- [0 .. 7]]
-  charsetIndex i = (checksum `shiftR` (5 * (7 - i))) .&. 31
-  symbols = expandChecksum desc <> replicate 8 0
-  checksum = 1 `xor` polymodChecksum symbols
+  where
+    checksumChars = [checksumCharset `charsetGet` charsetIndex i | i <- [0 .. 7]]
+    charsetIndex i = (checksum `shiftR` (5 * (7 - i))) .&. 31
+    symbols = expandChecksum desc <> replicate 8 0
+    checksum = 1 `xor` polymodChecksum symbols
+
 
 expandChecksum :: Text -> [Word]
 expandChecksum =
-  reverse . end
-    . foldl'
-      ( \(gs, s) v -> case (v `shiftR` 5 : gs, v .&. 31 : s) of
-          ([g2, g1, g0], s') -> ([], 9 * g0 + 3 * g1 + g2 : s')
-          x -> x
-      )
-      mempty
-    . fromMaybe []
-    . mapM (charsetFind inputCharset)
-    . Text.unpack
- where
-  end ([g0], s) = g0 : s
-  end ([g1, g0], s) = 3 * g0 + g1 : s
-  end (_, s) = s
+    reverse
+        . end
+        . foldl'
+            ( \(gs, s) v -> case (v `shiftR` 5 : gs, v .&. 31 : s) of
+                ([g2, g1, g0], s') -> ([], 9 * g0 + 3 * g1 + g2 : s')
+                x -> x
+            )
+            mempty
+        . fromMaybe []
+        . mapM (charsetFind inputCharset)
+        . Text.unpack
+  where
+    end ([g0], s) = g0 : s
+    end ([g1, g0], s) = 3 * g0 + g1 : s
+    end (_, s) = s
+
 
 polymodChecksum :: [Word] -> Word
 polymodChecksum =
-  foldl'
-    ( \chk value ->
-        foldl'
-          xor
-          ((chk .&. 0x7ffffffff) `shiftL` 5 `xor` value)
-          [if chk `testBit` i then g else 0 | i <- [35 ..] | g <- generator]
-    )
-    1
- where
-  generator =
-    [ 0xf5dee51989
-    , 0xa9fdca3312
-    , 0x1bab10e32d
-    , 0x3706b1677a
-    , 0x644d626ffd
-    ]
+    foldl'
+        ( \chk value ->
+            foldl'
+                xor
+                ((chk .&. 0x7ffffffff) `shiftL` 5 `xor` value)
+                [if chk `testBit` i then g else 0 | i <- [35 ..] | g <- generator]
+        )
+        1
+  where
+    generator =
+        [ 0xf5dee51989
+        , 0xa9fdca3312
+        , 0x1bab10e32d
+        , 0x3706b1677a
+        , 0x644d626ffd
+        ]
+
 
 data Charset = Charset
-  { charToIndex :: IntMap Word
-  , indexToChar :: Vector Char
-  }
+    { charToIndex :: IntMap Word
+    , indexToChar :: Vector Char
+    }
+
 
 charsetFromString :: String -> Charset
 charsetFromString s =
-  let xs = [(c, i) | c <- s | i <- [0 ..]]
-   in Charset
-        { charToIndex = IntMap.fromList $ first ord <$> xs
-        , indexToChar = Vector.fromList $ fst <$> xs
-        }
+    let xs = [(c, i) | c <- s | i <- [0 ..]]
+     in Charset
+            { charToIndex = IntMap.fromList $ first ord <$> xs
+            , indexToChar = Vector.fromList $ fst <$> xs
+            }
+
 
 charsetFind :: Charset -> Char -> Maybe Word
 charsetFind set c = IntMap.lookup (ord c) $ charToIndex set
 
+
 charsetGet :: Charset -> Word -> Maybe Char
 charsetGet set i = indexToChar set Vector.!? fromInteger (toInteger i)
 
+
 inputCharset :: Charset
 inputCharset = charsetFromString "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
+
 
 checksumCharset :: Charset
 checksumCharset = charsetFromString "qpzry9x8gf2tvdw0s3jn54khce6mua7l"

--- a/src/Language/Bitcoin/Script/Descriptors/Parser.hs
+++ b/src/Language/Bitcoin/Script/Descriptors/Parser.hs
@@ -48,6 +48,7 @@ import Language.Bitcoin.Utils (
     maybeFail,
  )
 
+
 -- | An 'OutputDescriptor' with checksum details
 data ChecksumDescriptor = ChecksumDescriptor
     { descriptor :: OutputDescriptor
@@ -59,20 +60,23 @@ data ChecksumDescriptor = ChecksumDescriptor
     }
     deriving (Eq, Show)
 
+
 -- | The status of an output descriptor's checksum
 data ChecksumStatus
     = -- | Checksum provided is valid
       Valid
     | -- | Checksum provided is invalid
       Invalid
+        -- | The invalid checksum
         Text
-        -- ^ The invalid checksum
     | -- | Checksum is not provided
       Absent
     deriving (Eq, Show)
 
+
 parseDescriptor :: Network -> Text -> Either String ChecksumDescriptor
 parseDescriptor = A.parseOnly . outputDescriptorParser
+
 
 outputDescriptorParser :: Network -> Parser ChecksumDescriptor
 outputDescriptorParser net =
@@ -104,6 +108,7 @@ outputDescriptorParser net =
         application "addr" (A.manyTill A.anyChar $ A.char ')')
             >>= maybeFail "descriptorParser: unable to parse address" Addr . textToAddr net . pack
 
+
 scriptDescriptorParser :: Network -> Parser ScriptDescriptor
 scriptDescriptorParser net = pkP <|> pkhP <|> rawP <|> multiP <|> sortedMultiP
   where
@@ -118,8 +123,10 @@ scriptDescriptorParser net = pkP <|> pkhP <|> rawP <|> multiP <|> sortedMultiP
 
     keyList = argList kp
 
+
 parseKeyDescriptor :: Network -> Text -> Either String KeyDescriptor
 parseKeyDescriptor net = A.parseOnly $ keyDescriptorParser net
+
 
 keyDescriptorParser :: Network -> Parser KeyDescriptor
 keyDescriptorParser net = KeyDescriptor <$> originP <*> keyP
@@ -148,6 +155,7 @@ keyDescriptorParser net = KeyDescriptor <$> originP <*> keyP
 
     famP = (HardKeys <$ A.string "/*'") <|> (SoftKeys <$ A.string "/*") <|> pure Single
 
+
 pathP :: Parser DerivPath
 pathP = go Deriv
   where
@@ -159,8 +167,10 @@ pathP = go Deriv
         isHard <- isJust <$> optional (A.char '\'' <|> A.char 'h')
         return $ bool (d :/) (d :|) isHard n
 
+
 parseTreeDescriptor :: Network -> Text -> Either String TreeDescriptor
 parseTreeDescriptor net = A.parseOnly $ treeDescriptorParser net
+
 
 treeDescriptorParser :: Network -> Parser TreeDescriptor
 treeDescriptorParser net =
@@ -168,6 +178,7 @@ treeDescriptorParser net =
         <|> braces (TapBranch <$> treeParser <*> comma treeParser)
   where
     treeParser = treeDescriptorParser net
+
 
 checksumParser :: Parser OutputDescriptor -> Parser ChecksumDescriptor
 checksumParser p = do

--- a/src/Language/Bitcoin/Script/Descriptors/Syntax.hs
+++ b/src/Language/Bitcoin/Script/Descriptors/Syntax.hs
@@ -30,6 +30,7 @@ import Haskoin (
     wrapPubKey,
  )
 
+
 -- | High level description for a bitcoin output
 data OutputDescriptor
     = -- | The output is secured by the given script.
@@ -54,6 +55,7 @@ data OutputDescriptor
       Addr Address
     deriving (Eq, Show)
 
+
 -- | High level description of a bitcoin script
 data ScriptDescriptor
     = -- | Require a signature for this key
@@ -68,17 +70,20 @@ data ScriptDescriptor
       Raw ByteString
     deriving (Eq, Show)
 
+
 data KeyDescriptor = KeyDescriptor
     { origin :: Maybe Origin
     , keyDef :: Key
     }
     deriving (Eq, Show)
 
+
 data Origin = Origin
     { fingerprint :: Fingerprint
     , derivation :: DerivPath
     }
     deriving (Eq, Ord, Show)
+
 
 data Key
     = -- | DER-hex encoded secp256k1 public key
@@ -91,22 +96,27 @@ data Key
       XOnlyPub XOnlyPubKey
     deriving (Eq, Show)
 
+
 data TreeDescriptor
     = TapLeaf ScriptDescriptor
     | TapBranch TreeDescriptor TreeDescriptor
     deriving (Eq, Show)
 
+
 -- | Simple explicit public key with no origin information
 pubKey :: PubKeyI -> KeyDescriptor
 pubKey = KeyDescriptor Nothing . Pubkey
+
 
 -- | Simple explicit secret key with no origin information
 secKey :: SecKeyI -> KeyDescriptor
 secKey = KeyDescriptor Nothing . SecretKey
 
+
 -- | Simple explicit x-only public key with no origin information
 xOnlyPubKey :: XOnlyPubKey -> KeyDescriptor
 xOnlyPubKey = KeyDescriptor Nothing . XOnlyPub
+
 
 -- | Represent whether the key corresponds to a collection (and how) or a single key.
 data KeyCollection
@@ -117,11 +127,13 @@ data KeyCollection
       SoftKeys
     deriving (Eq, Ord, Show)
 
+
 -- | Produce a key literal if possible
 keyBytes :: KeyDescriptor -> Maybe ByteString
 keyBytes = fmap toBytes . keyDescPubKey
   where
     toBytes (PubKeyI pk c) = exportPubKey c pk
+
 
 -- | Produce a pubkey if possible
 keyDescPubKey :: KeyDescriptor -> Maybe PubKeyI
@@ -131,6 +143,7 @@ keyDescPubKey (KeyDescriptor _ k) = case k of
     XPub xpub path Single -> (`PubKeyI` True) . xPubKey . (`derivePubPath` xpub) <$> toSoft path
     XOnlyPub (XOnlyPubKey pk) -> Just $ wrapPubKey True pk
     _ -> Nothing
+
 
 -- | Test whether the key descriptor corresponds to a single key
 isDefinite :: KeyDescriptor -> Bool

--- a/src/Language/Bitcoin/Script/Descriptors/Text.hs
+++ b/src/Language/Bitcoin/Script/Descriptors/Text.hs
@@ -15,24 +15,23 @@ import Data.Text (
     intercalate,
     pack,
  )
-import Haskoin (
-    Network,
-    PubKeyI (..),
-    addrToText,
-    encodeHex,
+import qualified Data.Text as Text
+import Haskoin.Address (addrToText)
+import Haskoin.Crypto (
+    PublicKey (..),
     exportPubKey,
     fingerprintToText,
     pathToStr,
     toWif,
     xPubExport,
  )
-
-import Data.Serialize (encode)
-import qualified Data.Text as Text
+import Haskoin.Network (Network)
+import Haskoin.Util (encodeHex, marshal)
 import Language.Bitcoin.Script.Descriptors.Checksum (descriptorChecksum)
 import Language.Bitcoin.Script.Descriptors.Syntax
 import Language.Bitcoin.Utils (
     applicationText,
+    globalContext,
     showText,
  )
 
@@ -84,10 +83,10 @@ keyDescriptorToText net (KeyDescriptor o k) = maybe mempty originText o <> defin
     originText (Origin fp path) = "[" <> fingerprintToText fp <> pack (pathToStr path) <> "]"
 
     definitionText = case k of
-        Pubkey (PubKeyI key c) -> encodeHex $ exportPubKey c key
+        PubKey (PublicKey key c) -> encodeHex $ exportPubKey globalContext c key
         SecretKey key -> toWif net key
-        XPub xpub path fam -> xPubExport net xpub <> (pack . pathToStr) path <> famText fam
-        XOnlyPub key -> encodeHex $ encode key
+        XPub xpub path fam -> xPubExport net globalContext xpub <> (pack . pathToStr) path <> famText fam
+        XOnlyPub key -> encodeHex $ marshal globalContext key
 
     famText = \case
         Single -> ""

--- a/src/Language/Bitcoin/Script/Descriptors/Text.hs
+++ b/src/Language/Bitcoin/Script/Descriptors/Text.hs
@@ -36,6 +36,7 @@ import Language.Bitcoin.Utils (
     showText,
  )
 
+
 descriptorToText :: Network -> OutputDescriptor -> Text
 descriptorToText net = \case
     ScriptPubKey x -> sdToText x
@@ -56,11 +57,13 @@ descriptorToText net = \case
 
     addrErr = error "Unable to parse address"
 
+
 descriptorToTextWithChecksum :: Network -> OutputDescriptor -> Text
 descriptorToTextWithChecksum net desc =
     descText <> maybe "" ("#" <>) (descriptorChecksum descText)
   where
     descText = descriptorToText net desc
+
 
 scriptDescriptorToText :: Network -> ScriptDescriptor -> Text
 scriptDescriptorToText net = \case
@@ -73,6 +76,7 @@ scriptDescriptorToText net = \case
         applicationText "sortedmulti" . intercalate "," $ showText k : (keyToText <$> ks)
   where
     keyToText = keyDescriptorToText net
+
 
 keyDescriptorToText :: Network -> KeyDescriptor -> Text
 keyDescriptorToText net (KeyDescriptor o k) = maybe mempty originText o <> definitionText
@@ -89,6 +93,7 @@ keyDescriptorToText net (KeyDescriptor o k) = maybe mempty originText o <> defin
         Single -> ""
         HardKeys -> "/*'"
         SoftKeys -> "/*"
+
 
 treeDescriptorToText :: Network -> TreeDescriptor -> Text
 treeDescriptorToText net = \case

--- a/src/Language/Bitcoin/Script/Utils.hs
+++ b/src/Language/Bitcoin/Script/Utils.hs
@@ -10,7 +10,8 @@ import Data.Bits (clearBit, setBit, testBit)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Word (Word8)
-import Haskoin (ScriptOp, intToScriptOp, opPushData)
+import Haskoin.Script (ScriptOp, intToScriptOp, opPushData)
+
 
 
 -- | Decode a numeric stack value

--- a/src/Language/Bitcoin/Script/Utils.hs
+++ b/src/Language/Bitcoin/Script/Utils.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString as BS
 import Data.Word (Word8)
 import Haskoin (ScriptOp, intToScriptOp, opPushData)
 
+
 -- | Decode a numeric stack value
 fromCScriptNum :: ByteString -> Int
 fromCScriptNum b
@@ -21,6 +22,7 @@ fromCScriptNum b
     | otherwise = leWord64 b
   where
     Just (b', msb) = BS.unsnoc b
+
 
 -- | Encode a numeric stack value
 toCScriptNum :: Int -> ByteString
@@ -34,10 +36,12 @@ toCScriptNum n
     (b', msb) = intLE n
     b = BS.snoc b' msb
 
+
 pushNumber :: Int -> ScriptOp
 pushNumber i
     | i <= 16 = intToScriptOp i
     | otherwise = opPushData $ toCScriptNum i
+
 
 intLE :: Int -> (ByteString, Word8)
 intLE = go mempty . abs
@@ -45,6 +49,7 @@ intLE = go mempty . abs
     go b n
         | n < 0xff = (b, fromIntegral n)
         | otherwise = let (q, r) = n `quotRem` 256 in go (BS.snoc b $ fromIntegral r) q
+
 
 leWord64 :: ByteString -> Int
 leWord64 bs = sum $ zipWith mult (BS.unpack bs) orders

--- a/src/Language/Bitcoin/Utils.hs
+++ b/src/Language/Bitcoin/Utils.hs
@@ -30,17 +30,22 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text, pack)
 import Haskoin.Util (decodeHex)
 
+
 parens :: Parser a -> Parser a
 parens p = A.char '(' >> p <* A.char ')'
+
 
 brackets :: Parser a -> Parser a
 brackets p = A.char '[' >> p <* A.char ']'
 
+
 braces :: Parser a -> Parser a
 braces p = A.char '{' >> p <* A.char '}'
 
+
 application :: Text -> Parser a -> Parser a
 application fname p = A.string fname >> parens (spacePadded p)
+
 
 hex :: Parser ByteString
 hex = A.many1' hexChar >>= maybeFail "Invalid hex" id . decodeHex . pack
@@ -48,30 +53,39 @@ hex = A.many1' hexChar >>= maybeFail "Invalid hex" id . decodeHex . pack
     hexChar = A.satisfy $ A.inClass chars
     chars = ['0' .. '9'] <> ['a' .. 'f'] <> ['A' .. 'F']
 
+
 -- | Allow for a leading comma
 comma :: Parser a -> Parser a
 comma p = spacePadded (A.char ',') >> p
 
+
 argList :: Parser a -> Parser [a]
 argList p = spacePadded p `A.sepBy` A.char ','
+
 
 alphanum :: Parser Char
 alphanum = A.digit <|> A.letter
 
+
 spacePadded :: Parser a -> Parser a
 spacePadded p = spaces >> p <* spaces
+
 
 spaces :: Parser ()
 spaces = void $ A.many' A.space
 
+
 showText :: Show a => a -> Text
 showText = pack . show
+
 
 applicationText :: Text -> Text -> Text
 applicationText f x = f <> "(" <> x <> ")"
 
+
 maybeFail :: String -> (a -> b) -> Maybe a -> Parser b
 maybeFail msg f = maybe (fail msg) (return . f)
+
 
 requiredContextValue :: (r -> Map Text c) -> e -> Text -> ReaderT r (Except e) c
 requiredContextValue f e name = asks (Map.lookup name . f) >>= maybe (lift $ throwE e) return

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,5 +5,6 @@ import Test.Tasty (defaultMain, testGroup)
 import Test.Descriptors (descriptorTests)
 import Test.Miniscript (miniscriptTests)
 
+
 main :: IO ()
 main = defaultMain $ testGroup "bitcoin scripting" [descriptorTests, miniscriptTests]

--- a/test/Test/Descriptors.hs
+++ b/test/Test/Descriptors.hs
@@ -6,20 +6,17 @@ module Test.Descriptors (
     descriptorTests,
 ) where
 
+import Data.Maybe (fromJust, fromMaybe)
 import Data.Text (Text)
-import Haskoin.Constants (btc)
-import Haskoin.Keys (
+import Haskoin.Crypto (
     DerivPathI (..),
-    PubKeyI (..),
+    PublicKey (..),
     importPubKey,
     xPubImport,
  )
-import Haskoin.Util (decodeHex)
-import Test.Tasty (TestTree, testGroup)
-
-import Data.Maybe (fromJust, fromMaybe)
-import Data.Serialize (decode)
-import Haskoin (XOnlyPubKey)
+import Haskoin.Network (btc)
+import Haskoin.Transaction (XOnlyPubKey)
+import Haskoin.Util (decodeHex, unmarshal)
 import Language.Bitcoin.Script.Descriptors (
     ChecksumDescriptor (..),
     ChecksumStatus (..),
@@ -38,18 +35,22 @@ import Language.Bitcoin.Script.Descriptors (
  )
 import Test.Descriptors.Utils (testDescriptorUtils)
 import Test.Example (Example (..), testTextRep)
+import Test.Tasty (TestTree, testGroup)
+import Test.Utils (globalContext)
 
 
 descriptorTests :: TestTree
 descriptorTests =
     testGroup "descriptor tests" $
-        [ testGroup "absent checksum" $
+        [ testGroup
+            "absent checksum"
             ( testTextRep
                 (parseDescriptor btc)
                 (descriptorToText btc . descriptor)
                 <$> absentChecksumExamples
             )
-        , testGroup "valid checksum" $
+        , testGroup
+            "valid checksum"
             ( testTextRep
                 (parseDescriptor btc)
                 (descriptorToTextWithChecksum btc . descriptor)
@@ -104,20 +105,20 @@ descriptorTests =
             ]
 
 
-key :: PubKeyI -> KeyDescriptor
-key = KeyDescriptor Nothing . Pubkey
+key :: PublicKey -> KeyDescriptor
+key = KeyDescriptor Nothing . PubKey
 
 
-hexPubkey :: Text -> PubKeyI
-hexPubkey h = PubKeyI k True
+hexPubkey :: Text -> PublicKey
+hexPubkey h = PublicKey k True
   where
-    Just k = importPubKey =<< decodeHex h
+    Just k = importPubKey globalContext =<< decodeHex h
 
 
 hexXOnlyPubkey :: Text -> XOnlyPubKey
 hexXOnlyPubkey h = k
   where
-    Right k = decode $ fromJust $ decodeHex h
+    Right k = unmarshal globalContext . fromJust $ decodeHex h
 
 
 withAbsentChecksum ::
@@ -300,6 +301,7 @@ example12 =
     Just xpub =
         xPubImport
             btc
+            globalContext
             "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
 
 
@@ -315,6 +317,7 @@ example13 =
     Just xpub =
         xPubImport
             btc
+            globalContext
             "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw"
 
 
@@ -330,6 +333,7 @@ example14 =
     Just xpub =
         xPubImport
             btc
+            globalContext
             "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
     fp = "d34db33f"
 
@@ -353,10 +357,12 @@ example15 =
     Just xpub1 =
         xPubImport
             btc
+            globalContext
             "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
     Just xpub2 =
         xPubImport
             btc
+            globalContext
             "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
 
 
@@ -379,10 +385,12 @@ example16 =
     Just xpub1 =
         xPubImport
             btc
+            globalContext
             "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
     Just xpub2 =
         xPubImport
             btc
+            globalContext
             "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
 
 

--- a/test/Test/Descriptors.hs
+++ b/test/Test/Descriptors.hs
@@ -17,7 +17,9 @@ import Haskoin.Keys (
 import Haskoin.Util (decodeHex)
 import Test.Tasty (TestTree, testGroup)
 
-import Data.Maybe (fromMaybe, fromJust)
+import Data.Maybe (fromJust, fromMaybe)
+import Data.Serialize (decode)
+import Haskoin (XOnlyPubKey)
 import Language.Bitcoin.Script.Descriptors (
     ChecksumDescriptor (..),
     ChecksumStatus (..),
@@ -27,16 +29,16 @@ import Language.Bitcoin.Script.Descriptors (
     Origin (..),
     OutputDescriptor (..),
     ScriptDescriptor (..),
+    TreeDescriptor (TapBranch, TapLeaf),
     descriptorChecksum,
     descriptorToText,
     descriptorToTextWithChecksum,
     parseDescriptor,
-    xOnlyPubKey, TreeDescriptor (TapBranch, TapLeaf)
+    xOnlyPubKey,
  )
 import Test.Descriptors.Utils (testDescriptorUtils)
 import Test.Example (Example (..), testTextRep)
-import Haskoin (XOnlyPubKey)
-import Data.Serialize (decode)
+
 
 descriptorTests :: TestTree
 descriptorTests =
@@ -101,18 +103,22 @@ descriptorTests =
             , "2rqrdjrh"
             ]
 
+
 key :: PubKeyI -> KeyDescriptor
 key = KeyDescriptor Nothing . Pubkey
+
 
 hexPubkey :: Text -> PubKeyI
 hexPubkey h = PubKeyI k True
   where
     Just k = importPubKey =<< decodeHex h
 
+
 hexXOnlyPubkey :: Text -> XOnlyPubKey
 hexXOnlyPubkey h = k
   where
     Right k = decode $ fromJust $ decodeHex h
+
 
 withAbsentChecksum ::
     Example OutputDescriptor -> Example ChecksumDescriptor
@@ -127,6 +133,7 @@ withAbsentChecksum example =
                 }
         }
 
+
 withValidChecksum ::
     Example OutputDescriptor -> Text -> Example ChecksumDescriptor
 withValidChecksum example checksum =
@@ -140,6 +147,7 @@ withValidChecksum example checksum =
         , text = text example <> "#" <> checksum
         }
 
+
 example1 :: Example OutputDescriptor
 example1 =
     Example
@@ -149,6 +157,7 @@ example1 =
         }
   where
     k = hexPubkey "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
 
 example2 :: Example OutputDescriptor
 example2 =
@@ -160,6 +169,7 @@ example2 =
   where
     k = hexPubkey "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
 
+
 example3 :: Example OutputDescriptor
 example3 =
     Example
@@ -169,6 +179,7 @@ example3 =
         }
   where
     k = hexPubkey "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
+
 
 example4 :: Example OutputDescriptor
 example4 =
@@ -180,6 +191,7 @@ example4 =
   where
     k = hexPubkey "03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556"
 
+
 example5 :: Example OutputDescriptor
 example5 =
     Example
@@ -190,6 +202,7 @@ example5 =
   where
     k = hexPubkey "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
 
+
 example6 :: Example OutputDescriptor
 example6 =
     Example
@@ -199,6 +212,7 @@ example6 =
         }
   where
     k = hexPubkey "02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13"
+
 
 example7 :: Example OutputDescriptor
 example7 =
@@ -213,6 +227,7 @@ example7 =
     k1 = hexPubkey "022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4"
     k2 = hexPubkey "025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc"
 
+
 example8 :: Example OutputDescriptor
 example8 =
     Example
@@ -226,6 +241,7 @@ example8 =
     k1 = hexPubkey "022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01"
     k2 = hexPubkey "03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe"
 
+
 example9 :: Example OutputDescriptor
 example9 =
     Example
@@ -238,6 +254,7 @@ example9 =
   where
     k1 = hexPubkey "03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe"
     k2 = hexPubkey "022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01"
+
 
 example10 :: Example OutputDescriptor
 example10 =
@@ -254,6 +271,7 @@ example10 =
     k2 = hexPubkey "03774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb"
     k3 = hexPubkey "03d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a"
 
+
 example11 :: Example OutputDescriptor
 example11 =
     Example
@@ -269,36 +287,52 @@ example11 =
     k2 = hexPubkey "03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4"
     k3 = hexPubkey "02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e"
 
+
 example12 :: Example OutputDescriptor
 example12 =
     Example
         { name = "xpub"
-        , text = "pk(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8)"
+        , text =
+            "pk(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8)"
         , script = ScriptPubKey . Pk $ KeyDescriptor Nothing (XPub xpub Deriv Single)
         }
   where
-    Just xpub = xPubImport btc "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+    Just xpub =
+        xPubImport
+            btc
+            "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+
 
 example13 :: Example OutputDescriptor
 example13 =
     Example
         { name = "p2pkh-xpub with derivation"
-        , text = "pkh(xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw/1'/2)"
+        , text =
+            "pkh(xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw/1'/2)"
         , script = ScriptPubKey . Pkh $ KeyDescriptor Nothing (XPub xpub (Deriv :| 1 :/ 2) Single)
         }
   where
-    Just xpub = xPubImport btc "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw"
+    Just xpub =
+        xPubImport
+            btc
+            "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw"
+
 
 example14 :: Example OutputDescriptor
 example14 =
     Example
         { name = "pkh-xpub with origin and collection spec"
-        , text = "pkh([d34db33f/44'/0'/0']xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*)"
+        , text =
+            "pkh([d34db33f/44'/0'/0']xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*)"
         , script = ScriptPubKey . Pkh $ KeyDescriptor (Just (Origin fp (Deriv :| 44 :| 0 :| 0))) (XPub xpub (Deriv :/ 1) SoftKeys)
         }
   where
-    Just xpub = xPubImport btc "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+    Just xpub =
+        xPubImport
+            btc
+            "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
     fp = "d34db33f"
+
 
 example15 :: Example OutputDescriptor
 example15 =
@@ -316,8 +350,15 @@ example15 =
                     ]
         }
   where
-    Just xpub1 = xPubImport btc "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
-    Just xpub2 = xPubImport btc "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
+    Just xpub1 =
+        xPubImport
+            btc
+            "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
+    Just xpub2 =
+        xPubImport
+            btc
+            "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
+
 
 example16 :: Example OutputDescriptor
 example16 =
@@ -335,8 +376,15 @@ example16 =
                     ]
         }
   where
-    Just xpub1 = xPubImport btc "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
-    Just xpub2 = xPubImport btc "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
+    Just xpub1 =
+        xPubImport
+            btc
+            "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
+    Just xpub2 =
+        xPubImport
+            btc
+            "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
+
 
 example17 :: Example OutputDescriptor
 example17 =
@@ -348,11 +396,12 @@ example17 =
   where
     k = xOnlyPubKey $ hexXOnlyPubkey "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
 
+
 example18 :: Example OutputDescriptor
 example18 =
     Example
         { name = "tr with 2 pk script paths"
-        , text = 
+        , text =
             "tr(c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5,\
             \{pk(fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556),\
             \pk(e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13)})"

--- a/test/Test/Descriptors/Utils.hs
+++ b/test/Test/Descriptors/Utils.hs
@@ -72,6 +72,7 @@ import Language.Bitcoin.Script.Descriptors (
     toPsbtInput,
  )
 
+
 testDescriptorUtils :: TestTree
 testDescriptorUtils =
     testGroup
@@ -83,6 +84,7 @@ testDescriptorUtils =
         , testKeyAtIndex
         , testToPsbtInput
         ]
+
 
 -- Address tests generated using @bitcoin-cli deriveaddresses@
 testAddresses :: TestTree
@@ -99,6 +101,7 @@ testAddresses =
         , testP2TR
         ]
 
+
 testKeyAtIndex :: TestTree
 testKeyAtIndex =
     testGroup
@@ -107,11 +110,13 @@ testKeyAtIndex =
         , testOutputDescriptorAtIndex
         ]
 
+
 testP2PKH :: TestTree
 testP2PKH = testCase "P2PKH" $ descriptorAddresses example @?= [expected]
   where
     example = ScriptPubKey . Pkh $ pubKey key0
     Just expected = textToAddr btcRegTest "mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r"
+
 
 testP2SH :: TestTree
 testP2SH = testCase "P2SH" $ descriptorAddresses example @?= [expected]
@@ -120,11 +125,13 @@ testP2SH = testCase "P2SH" $ descriptorAddresses example @?= [expected]
     Just expected = textToAddr btcRegTest "2MuFU6ZyBLtDNadMA6RnwJdXGWUSUaoKLeS"
     ks = pubKey <$> take 3 testPubKeys
 
+
 testP2WPKH :: TestTree
 testP2WPKH = testCase "P2WPKH" $ descriptorAddresses example @?= [expected]
   where
     example = P2WPKH $ pubKey key0
     Just expected = textToAddr btcRegTest "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080"
+
 
 testP2WSH :: TestTree
 testP2WSH = testCase "P2WSH" $ descriptorAddresses example @?= [expected]
@@ -132,11 +139,13 @@ testP2WSH = testCase "P2WSH" $ descriptorAddresses example @?= [expected]
     example = P2WSH . Pkh $ pubKey key0
     Just expected = textToAddr btcRegTest "bcrt1q8a9wr6e7whe40py3sywj066euga9zt8ep3emz0r2e4zfna7y629sq89pz7"
 
+
 testWrappedWPhk :: TestTree
 testWrappedWPhk = testCase "Wrapped P2WPKH" $ descriptorAddresses example @?= [expected]
   where
     example = WrappedWPkh $ pubKey key0
     Just expected = textToAddr btcRegTest "2NAUYAHhujozruyzpsFRP63mbrdaU5wnEpN"
+
 
 testWrappedWSh :: TestTree
 testWrappedWSh = testCase "Wrapped P2WSH" $ descriptorAddresses example @?= [expected]
@@ -144,6 +153,7 @@ testWrappedWSh = testCase "Wrapped P2WSH" $ descriptorAddresses example @?= [exp
     example = WrappedWSh $ SortedMulti 2 ks
     ks = pubKey <$> take 3 testPubKeys
     Just expected = textToAddr btcRegTest "2NBbyaKyqn2AhMzSnQZrVPAW46KW1it9v7r"
+
 
 testCombo :: TestTree
 testCombo = testCase "Combo" $ sort (descriptorAddresses example) @?= sort expected
@@ -157,6 +167,7 @@ testCombo = testCase "Combo" $ sort (descriptorAddresses example) @?= sort expec
             , "2NAUYAHhujozruyzpsFRP63mbrdaU5wnEpN"
             ]
 
+
 testP2TR :: TestTree
 testP2TR =
     testGroup
@@ -165,6 +176,7 @@ testP2TR =
         , testP2TRSingleScriptPath
         , testP2TRMultiScriptPaths
         ]
+
 
 testP2TRInternalKeyOnly :: TestTree
 testP2TRInternalKeyOnly =
@@ -177,6 +189,7 @@ testP2TRInternalKeyOnly =
             btcRegTest
             "bcrt1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ssm803es"
 
+
 testP2TRSingleScriptPath :: TestTree
 testP2TRSingleScriptPath =
     testCase "P2TR tree (single script path)" $
@@ -188,6 +201,7 @@ testP2TRSingleScriptPath =
             btcRegTest
             "bcrt1pg44et8f66qnjn5fd0hu6dnnx7tczqslmt3dkzpccjlzeg99psshqfkkdep"
     _ : key1 : _ = testPubKeys
+
 
 testP2TRMultiScriptPaths :: TestTree
 testP2TRMultiScriptPaths =
@@ -206,14 +220,17 @@ testP2TRMultiScriptPaths =
             "bcrt1pprj5dr4rgrw835zyx8ncp9qe54n3ljcgcft0tw9mlj657udee6nq47mg8u"
     _ : key1 : key2 : _ = testPubKeys
 
+
 testCompile :: TestTree
 testCompile = testGroup "compile" [testPk, testPkh, testMulti, testSortedMulti]
+
 
 testPk :: TestTree
 testPk = testCase "Pk" $ compile example @?= Just expected
   where
     example = Pk $ pubKey key0
     expected = Script [opPushData (encode key0), OP_CHECKSIG]
+
 
 testPkh :: TestTree
 testPkh = testCase "Pkh" $ compile example @?= Just expected
@@ -222,12 +239,14 @@ testPkh = testCase "Pkh" $ compile example @?= Just expected
     expected = Script [OP_DUP, OP_HASH160, opPushData (encode keyHash), OP_EQUALVERIFY, OP_CHECKSIG]
     keyHash = ripemd160 $ encode key0
 
+
 testMulti :: TestTree
 testMulti = testCase "Multi" $ compile example @?= Just expected
   where
     example = Multi 2 $ pubKey <$> ks
     expected = Script [OP_2, opPushData (encode k0), opPushData (encode k1), opPushData (encode k2), OP_3, OP_CHECKMULTISIG]
     ks@[k0, k1, k2] = take 3 testPubKeys
+
 
 testSortedMulti :: TestTree
 testSortedMulti = testCase "SortedMulti" $ compile example @?= Just expected
@@ -237,8 +256,10 @@ testSortedMulti = testCase "SortedMulti" $ compile example @?= Just expected
     ks = take 3 testPubKeys
     [k0, k1, k2] = sort $ encode <$> ks
 
+
 testCompileTree :: TestTree
 testCompileTree = testGroup "testCompileTree" [testTapLeaf, testTapBranch]
+
 
 testTapLeaf :: TestTree
 testTapLeaf =
@@ -253,6 +274,7 @@ testTapLeaf =
                 [ opPushData (encode $ XOnlyPubKey $ pubKeyPoint $ key0)
                 , OP_CHECKSIG
                 ]
+
 
 testTapBranch :: TestTree
 testTapBranch =
@@ -280,8 +302,10 @@ testTapBranch =
             )
     _ : key1 : _ = testPubKeys
 
+
 testCompileTapLeaf :: TestTree
 testCompileTapLeaf = testGroup "testCompileTapLeaf" [testTapLeafPk]
+
 
 testTapLeafPk :: TestTree
 testTapLeafPk = testCase "Pk" $ compileTapLeaf example @?= Just expected
@@ -292,6 +316,7 @@ testTapLeafPk = testCase "Pk" $ compileTapLeaf example @?= Just expected
             [ opPushData (encode $ XOnlyPubKey $ pubKeyPoint $ key0)
             , OP_CHECKSIG
             ]
+
 
 testKeyDescriptorAtIndex :: TestTree
 testKeyDescriptorAtIndex = testCase "keyDescriptorAtIndex" $ do
@@ -306,6 +331,7 @@ testKeyDescriptorAtIndex = testCase "keyDescriptorAtIndex" $ do
     keyB = KeyDescriptor Nothing $ XPub someXPubA (basePath :/ 5) Single
 
     keyC = KeyDescriptor Nothing $ XPub someXPubA basePath Single
+
 
 testOutputDescriptorAtIndex :: TestTree
 testOutputDescriptorAtIndex = testCase "outputDescriptorAtIndex" $ do
@@ -331,6 +357,7 @@ testOutputDescriptorAtIndex = testCase "outputDescriptorAtIndex" $ do
 
     keyFamB = KeyDescriptor Nothing $ XPub someXPubB basePath HardKeys
     keyB = KeyDescriptor Nothing $ XPub someXPubB (basePath :| 5) Single
+
 
 testToPsbtInput :: TestTree
 testToPsbtInput = testCaseSteps "toPsbtInput" $ \step -> do
@@ -439,15 +466,24 @@ testToPsbtInput = testCaseSteps "toPsbtInput" $ \step -> do
     path = Deriv :/ 1 :: DerivPath
     Just softPath = toSoft path
 
+
 key0 :: PubKeyI
 testPubKeys :: [PubKeyI]
 testPubKeys@(key0 : _) = (`PubKeyI` True) . derivePubKey <$> mapMaybe (secKey . mkSecKey) [1 .. 255]
   where
     mkSecKey i = BS.pack $ replicate 31 0 <> [i]
 
+
 someXPubA, someXPubB :: XPubKey
-Just someXPubA = xPubImport btc "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
-Just someXPubB = xPubImport btc "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
+Just someXPubA =
+    xPubImport
+        btc
+        "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
+Just someXPubB =
+    xPubImport
+        btc
+        "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
+
 
 basePath :: DerivPath
 basePath = Deriv :| 1500

--- a/test/Test/Example.hs
+++ b/test/Test/Example.hs
@@ -9,11 +9,13 @@ import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (assertFailure, testCase, (@=?))
 import Test.Tasty.QuickCheck (Property, testProperty)
 
+
 data Example a = Example
     { name :: String
     , text :: Text
     , script :: a
     }
+
 
 testTextRep ::
     (Eq a, Show a) =>
@@ -29,6 +31,7 @@ testTextRep parse encode e =
     parseSuccess d = do
         d @=? script e
         encode d @=? text e
+
 
 testExampleProperty :: Example a -> Property -> TestTree
 testExampleProperty e = testProperty (name e)

--- a/test/Test/Miniscript.hs
+++ b/test/Test/Miniscript.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-{- |
- Module: Test.Miniscript
-
- Examples taken from <http://bitcoin.sipa.be/miniscript/>
--}
+-- |
+--  Module: Test.Miniscript
+--
+--  Examples taken from <http://bitcoin.sipa.be/miniscript/>
 module Test.Miniscript (
     miniscriptTests,
 ) where
@@ -19,6 +18,7 @@ import Test.Miniscript.Examples
 import Test.Miniscript.Types (typeCheckerTests)
 import Test.Miniscript.Witness (witnessTests)
 
+
 miniscriptTests :: TestTree
 miniscriptTests =
     testGroup
@@ -28,6 +28,7 @@ miniscriptTests =
         , compilerTests
         , witnessTests
         ]
+
 
 parsePrintTests :: TestTree
 parsePrintTests =

--- a/test/Test/Miniscript.hs
+++ b/test/Test/Miniscript.hs
@@ -8,15 +8,15 @@ module Test.Miniscript (
     miniscriptTests,
 ) where
 
-import Haskoin.Constants (btc)
-import Test.Tasty (TestTree, testGroup)
-
+import Haskoin.Network (btc)
 import Language.Bitcoin.Miniscript (miniscriptToText, parseMiniscript)
 import Test.Example (testTextRep)
 import Test.Miniscript.Compiler (compilerTests)
 import Test.Miniscript.Examples
 import Test.Miniscript.Types (typeCheckerTests)
 import Test.Miniscript.Witness (witnessTests)
+import Test.Tasty (TestTree, testGroup)
+
 
 
 miniscriptTests :: TestTree

--- a/test/Test/Miniscript/Compiler.hs
+++ b/test/Test/Miniscript/Compiler.hs
@@ -16,18 +16,7 @@ import Haskoin.Script (
     ScriptOp (..),
     opPushData,
  )
-import Haskoin.Util.Arbitrary.Keys (arbitraryKeyPair)
-import Haskoin.Util.Arbitrary.Util (arbitraryBSn)
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (
-    Gen,
-    Property,
-    Testable,
-    forAll,
-    property,
-    (===),
- )
-
+import Haskoin.Util.Arbitrary (arbitraryBSn, arbitraryKeyPair)
 import Language.Bitcoin.Miniscript (
     Miniscript (..),
     compile,
@@ -44,7 +33,17 @@ import Test.Example (
     testExampleProperty,
  )
 import qualified Test.Miniscript.Examples as E
-import Test.Utils (forAllLabeled, pr12, pr3)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (
+    Gen,
+    Property,
+    Testable,
+    forAll,
+    property,
+    (===),
+ )
+import Test.Utils (forAllLabeled, globalContext, pr12, pr3)
+
 
 
 compilerTests :: TestTree
@@ -65,7 +64,8 @@ compilerTests = testGroup "compiler" examples
 
 
 arbitraryKey :: Gen KeyDescriptor
-arbitraryKey = pubKey . snd <$> arbitraryKeyPair
+arbitraryKey = pubKey . snd <$> arbitraryKeyPair globalContext
+
 
 
 keyB :: Text -> KeyDescriptor -> (Text, Miniscript, ByteString)

--- a/test/Test/Miniscript/Compiler.hs
+++ b/test/Test/Miniscript/Compiler.hs
@@ -46,6 +46,7 @@ import Test.Example (
 import qualified Test.Miniscript.Examples as E
 import Test.Utils (forAllLabeled, pr12, pr3)
 
+
 compilerTests :: TestTree
 compilerTests = testGroup "compiler" examples
   where
@@ -62,28 +63,36 @@ compilerTests = testGroup "compiler" examples
         , example10
         ]
 
+
 arbitraryKey :: Gen KeyDescriptor
 arbitraryKey = pubKey . snd <$> arbitraryKeyPair
+
 
 keyB :: Text -> KeyDescriptor -> (Text, Miniscript, ByteString)
 keyB n k = (n, KeyDesc k, bs)
   where
     Just bs = keyBytes k
 
+
 pushHash :: ByteString -> ScriptOp
 pushHash = opPushData . encode . ripemd160
+
 
 forKeys :: Testable p => [Text] -> ([(Text, Miniscript, ByteString)] -> p) -> Property
 forKeys = forAllLabeled arbitraryKey keyB
 
+
 arbitraryBytes32 :: Gen ByteString
 arbitraryBytes32 = arbitraryBSn 32
+
 
 scriptCompiles :: Example Miniscript -> [(Text, Miniscript)] -> Property
 scriptCompiles e bs = void (compile . let_ bs $ script e) === Right ()
 
+
 scriptCompilesTo :: Example Miniscript -> [(Text, Miniscript)] -> Script -> Property
 scriptCompilesTo e bs s = compile (let_ bs $ script e) === Right s
+
 
 example1 :: TestTree
 example1 = testExampleProperty E.example1 $
@@ -91,11 +100,13 @@ example1 = testExampleProperty E.example1 $
         let Just bs = keyBytes k
          in scriptCompilesTo E.example1 [("key_1", KeyDesc k)] $ Script [opPushData bs, OP_CHECKSIG]
 
+
 example2 :: TestTree
 example2 = testExampleProperty E.example2 . forKeys ["key_1", "key_2"] $ \ks ->
     scriptCompilesTo E.example2 (pr12 <$> ks) $ result (pr3 <$> ks)
   where
     result [k1, k2] = Script [opPushData k1, OP_CHECKSIG, OP_SWAP, opPushData k2, OP_CHECKSIG, OP_BOOLOR]
+
 
 example3 :: TestTree
 example3 = testExampleProperty E.example3 . forKeys ["key_likely", "key_unlikely"] $ \ks ->
@@ -115,6 +126,7 @@ example3 = testExampleProperty E.example3 . forKeys ["key_likely", "key_unlikely
             , OP_ENDIF
             ]
 
+
 example4 :: TestTree
 example4 = testExampleProperty E.example4 . forKeys ["key_user", "key_service"] $ \ks ->
     scriptCompilesTo E.example4 (pr12 <$> ks) $ result (pr3 <$> ks)
@@ -131,6 +143,7 @@ example4 = testExampleProperty E.example4 . forKeys ["key_user", "key_service"] 
             , OP_CHECKSEQUENCEVERIFY
             , OP_ENDIF
             ]
+
 
 example5 :: TestTree
 example5 = testExampleProperty E.example5 . forKeys ["key_1", "key_2", "key_3"] $ \ks ->
@@ -160,6 +173,7 @@ example5 = testExampleProperty E.example5 . forKeys ["key_1", "key_2", "key_3"] 
             , OP_EQUAL
             ]
 
+
 example6 :: TestTree
 example6 = testExampleProperty E.example6 . forKeys ["key_local", "key_revocation"] $ \ks ->
     scriptCompilesTo E.example6 (pr12 <$> ks) $ result (pr3 <$> ks)
@@ -176,6 +190,7 @@ example6 = testExampleProperty E.example6 . forKeys ["key_local", "key_revocatio
             , OP_CHECKSEQUENCEVERIFY
             , OP_ENDIF
             ]
+
 
 example7 :: TestTree
 example7 = testExampleProperty E.example7 . forKeys ["key_local", "key_revocation", "key_remote"] $ \ks ->
@@ -204,6 +219,7 @@ example7 = testExampleProperty E.example7 . forKeys ["key_local", "key_revocatio
             , OP_ENDIF
             , OP_1
             ]
+
 
 example8 :: TestTree
 example8 = testExampleProperty E.example8 . forKeys ["key_revocation", "key_remote", "key_local"] $ \ks ->
@@ -239,8 +255,10 @@ example8 = testExampleProperty E.example8 . forKeys ["key_revocation", "key_remo
             , OP_ENDIF
             ]
 
+
 example9 :: TestTree
 example9 = testExampleProperty E.example9 . property $ scriptCompiles E.example9 mempty
+
 
 example10 :: TestTree
 example10 = testExampleProperty E.example10 $

--- a/test/Test/Miniscript/Examples.hs
+++ b/test/Test/Miniscript/Examples.hs
@@ -25,11 +25,14 @@ import Language.Bitcoin.Miniscript (
  )
 import Test.Example (Example (..))
 
+
 keyVar :: Text -> Miniscript
 keyVar = AnnC . Key . var
 
+
 keyHVar :: Text -> Miniscript
 keyHVar = AnnC . KeyH . var
+
 
 example1 :: Example Miniscript
 example1 =
@@ -39,6 +42,7 @@ example1 =
         , script = keyVar "key_1"
         }
 
+
 example2 :: Example Miniscript
 example2 =
     Example
@@ -46,6 +50,7 @@ example2 =
         , text = "or_b(pk(key_1),s:pk(key_2))"
         , script = keyVar "key_1" `OrB` (S .: keyVar "key_2")
         }
+
 
 example3 :: Example Miniscript
 example3 =
@@ -55,6 +60,7 @@ example3 =
         , script = keyVar "key_likely" `OrD` keyHVar "key_unlikely"
         }
 
+
 example4 :: Example Miniscript
 example4 =
     Example
@@ -62,6 +68,7 @@ example4 =
         , text = "and_v(v:pk(key_user),or_d(pk(key_service),older(12960)))"
         , script = AndV (V .: keyVar "key_user") (keyVar "key_service" `OrD` older 12960)
         }
+
 
 example5 :: Example Miniscript
 example5 =
@@ -78,6 +85,7 @@ example5 =
                 ]
         }
 
+
 example6 :: Example Miniscript
 example6 =
     Example
@@ -85,6 +93,7 @@ example6 =
         , text = "andor(pk(key_local),older(1008),pk(key_revocation))"
         , script = AndOr (keyVar "key_local") (older 1008) (keyVar "key_revocation")
         }
+
 
 example7 :: Example Miniscript
 example7 =
@@ -100,6 +109,7 @@ example7 =
                    )
         }
 
+
 example8 :: Example Miniscript
 example8 =
     Example
@@ -112,6 +122,7 @@ example8 =
                 (keyVar "key_revocation")
         }
 
+
 example9 :: Example Miniscript
 example9 =
     Example
@@ -119,6 +130,7 @@ example9 =
         , text = "let timeout = 1008 in older(timeout)"
         , script = Let "timeout" (Number 1008) $ Older (var "timeout")
         }
+
 
 -- ht @shesek
 example10 :: Example Miniscript

--- a/test/Test/Miniscript/Types.hs
+++ b/test/Test/Miniscript/Types.hs
@@ -4,16 +4,7 @@ module Test.Miniscript.Types (
     typeCheckerTests,
 ) where
 
-import Haskoin.Util.Arbitrary.Keys (arbitraryKeyPair)
-import Haskoin.Util.Arbitrary.Util (arbitraryBSn)
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (
-    Gen,
-    forAll,
-    testProperty,
-    (===),
- )
-
+import Haskoin.Util.Arbitrary (arbitraryBSn, arbitraryKeyPair)
 import Language.Bitcoin.Miniscript (
     BaseType (..),
     Miniscript (..),
@@ -28,6 +19,15 @@ import Test.Miniscript.Examples (
     example7,
     example8,
  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (
+    Gen,
+    forAll,
+    testProperty,
+    (===),
+ )
+import Test.Utils (globalContext)
+
 
 
 typeCheckerTests :: TestTree
@@ -35,7 +35,8 @@ typeCheckerTests = testGroup "type checker" [localPolicy, offeredPolicy, receive
 
 
 arbitraryKey :: Gen KeyDescriptor
-arbitraryKey = pubKey . snd <$> arbitraryKeyPair
+arbitraryKey = pubKey . snd <$> arbitraryKeyPair globalContext
+
 
 
 localPolicy :: TestTree

--- a/test/Test/Miniscript/Types.hs
+++ b/test/Test/Miniscript/Types.hs
@@ -29,11 +29,14 @@ import Test.Miniscript.Examples (
     example8,
  )
 
+
 typeCheckerTests :: TestTree
 typeCheckerTests = testGroup "type checker" [localPolicy, offeredPolicy, receivedPolicy]
 
+
 arbitraryKey :: Gen KeyDescriptor
 arbitraryKey = pubKey . snd <$> arbitraryKeyPair
+
 
 localPolicy :: TestTree
 localPolicy = testProperty "bolt3 local policy" $
@@ -47,6 +50,7 @@ localPolicy = testProperty "bolt3 local policy" $
             , ("key_revocation", KeyDesc rev)
             ]
             $ script example6
+
 
 offeredPolicy :: TestTree
 offeredPolicy = testProperty "bolt 3 offered policy" $
@@ -64,6 +68,7 @@ offeredPolicy = testProperty "bolt 3 offered policy" $
             , ("H", Bytes h)
             ]
             $ script example7
+
 
 receivedPolicy :: TestTree
 receivedPolicy = testProperty "bolt 3 received policy" $

--- a/test/Test/Miniscript/Witness.hs
+++ b/test/Test/Miniscript/Witness.hs
@@ -52,6 +52,7 @@ import Test.Example (
 import qualified Test.Miniscript.Examples as E
 import Test.Utils (forAllLabeled, pr23)
 
+
 witnessTests :: TestTree
 witnessTests = testGroup "witness" examples
   where
@@ -68,11 +69,14 @@ witnessTests = testGroup "witness" examples
         , example10
         ]
 
+
 pushKey :: PubKeyI -> ScriptOp
 pushKey = opPushData . encode
 
+
 pushSig :: Signature -> ScriptOp
 pushSig (Signature s sh) = opPushData . encodeTxSig $ TxSignature s sh
+
 
 forKeys :: Testable p => [Text] -> Miniscript -> ([(PubKeyI, Signature)] -> Miniscript -> p) -> Property
 forKeys ls scr k = forAllLabeled arbKeySig mkRow ls mkProp
@@ -80,6 +84,7 @@ forKeys ls scr k = forAllLabeled arbKeySig mkRow ls mkProp
     mkRow label (pk, s) = (label, pk, s)
     mkProp xs = k (pr23 <$> xs) $ let_ (binding <$> xs) scr
     binding (l, pk, _) = (l, KeyDesc $ pubKey pk)
+
 
 arbKeySig :: Gen (PubKeyI, Signature)
 arbKeySig = repack <$> arbitraryKeyPair
@@ -91,6 +96,7 @@ arbKeySig = repack <$> arbitraryKeyPair
     msg :: ByteString
     msg = "arbKeySig"
 
+
 testExample ::
     Testable p =>
     Example Miniscript ->
@@ -99,10 +105,12 @@ testExample ::
     TestTree
 testExample e ls = testExampleProperty e . forKeys ls (script e)
 
+
 example1 :: TestTree
 example1 = testExample E.example1 ["key_1"] test
   where
     test [(k, s)] scr = satisfy emptyChainState (signature k s) scr === Right (Script [pushSig s])
+
 
 example2 :: TestTree
 example2 = testExample E.example2 ["key_1", "key_2"] test
@@ -112,6 +120,7 @@ example2 = testExample E.example2 ["key_1", "key_2"] test
     expected ((_, s) : _) = Script [OP_0, pushSig s]
     context (x : _) = uncurry signature x
 
+
 example3 :: TestTree
 example3 = testExample E.example3 ["key_likely", "key_unlikely"] test
   where
@@ -119,6 +128,7 @@ example3 = testExample E.example3 ["key_likely", "key_unlikely"] test
 
     expected (_ : (k, s) : _) = Script [pushSig s, pushKey k, OP_0]
     context (_ : x : _) = uncurry signature x
+
 
 example4 :: TestTree
 example4 = testExample E.example4 ["key_user", "key_service"] test
@@ -129,6 +139,7 @@ example4 = testExample E.example4 ["key_user", "key_service"] test
     context (x : _) = uncurry signature x
 
     chainState = ChainState{blockHeight = Nothing, utxoAge = Just 20000}
+
 
 example5 :: TestTree
 example5 = testExample E.example5 ["key_1", "key_2", "key_3"] test
@@ -141,6 +152,7 @@ example5 = testExample E.example5 ["key_1", "key_2", "key_3"] test
 
     chainState = ChainState{blockHeight = Nothing, utxoAge = Just 13000}
 
+
 example6 :: TestTree
 example6 = testExample E.example6 ["key_local", "key_revocation"] test
   where
@@ -152,8 +164,10 @@ example6 = testExample E.example6 ["key_local", "key_revocation"] test
 
     chainState = ChainState{blockHeight = Nothing, utxoAge = Just 100}
 
+
 hashBinding :: ByteString -> Miniscript -> Miniscript
 hashBinding bs = let_ [("H", Bytes . encode $ ripemd160 bs)]
+
 
 example7 :: TestTree
 example7 = testExample E.example7 ["key_local", "key_remote", "key_revocation"] test
@@ -166,6 +180,7 @@ example7 = testExample E.example7 ["key_local", "key_remote", "key_revocation"] 
 
     chainState = ChainState{blockHeight = Nothing, utxoAge = Just 2000}
 
+
 example8 :: TestTree
 example8 = testExample E.example8 ["key_local", "key_remote", "key_revocation"] test
   where
@@ -177,11 +192,13 @@ example8 = testExample E.example8 ["key_local", "key_remote", "key_revocation"] 
 
     chainState = ChainState{blockHeight = Nothing, utxoAge = Just 6}
 
+
 example9 :: TestTree
 example9 = testExample E.example9 [] test
   where
     test _ scr = satisfy chainState mempty scr === Left Impossible
     chainState = ChainState{blockHeight = Nothing, utxoAge = Just 100}
+
 
 example10 :: TestTree
 example10 = testExample E.example10 ["A", "B", "C", "D", "E", "F", "G", "H"] test

--- a/test/Test/Utils.hs
+++ b/test/Test/Utils.hs
@@ -3,9 +3,12 @@ module Test.Utils (
     pr12,
     pr23,
     pr3,
+    globalContext,
 ) where
 
 import Data.Text (Text)
+import Haskoin.Crypto (Ctx, createContext)
+import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty.QuickCheck (
     Gen,
     Property,
@@ -36,3 +39,11 @@ forAllLabeled ::
     Property
 forAllLabeled g mkRow (l : ls) mkTest = forAll g $ \z -> forAllLabeled g mkRow ls $ mkTest . (mkRow l z :)
 forAllLabeled _ _ _ mkTest = property $ mkTest []
+
+
+-- | The global context is created once and never modified again, it is to be passed into cryptographic
+-- functions and contains a number of large data structures that are generated at runtime. Impure functions like
+-- `destroyContext` or `randomizeContext` must not be used against this global value
+globalContext :: Ctx
+globalContext = unsafePerformIO createContext
+{-# NOINLINE globalContext #-}

--- a/test/Test/Utils.hs
+++ b/test/Test/Utils.hs
@@ -14,14 +14,18 @@ import Test.Tasty.QuickCheck (
     property,
  )
 
+
 pr12 :: (a, b, c) -> (a, b)
 pr12 (x, y, _) = (x, y)
+
 
 pr23 :: (a, b, c) -> (b, c)
 pr23 (_, x, y) = (x, y)
 
+
 pr3 :: (a, b, c) -> c
 pr3 (_, _, x) = x
+
 
 forAllLabeled ::
     (Testable p, Show a) =>


### PR DESCRIPTION
This PR upgrades bitcoin-scripting to use the newer version of haskoin-core, the one included in the Stack LTS 22. 

Apart from some name changes, the most significant change is that functions that relied on the secp25k1 context now pass that in explicitly. Consequently, some functions for serializing/encoding have changed, and many functions have had a `Ctx` parameter added.

This PR also adds a `fourmolu.yaml`, with the same settings used in other bitnomial repositories.

Also, in haskoin-core, accessor functions have been removed for record types, they're preferring to use `OverloadedRecordDot` syntax, so in some modules that has been added here.

# Testing

The test suite all pass with the new changes
