### PR TITLE
Bumped cabal deps for stackage LTS 23.X

### DIFF
--- a/bitcoin-scripting.cabal
+++ b/bitcoin-scripting.cabal
@@ -29,10 +29,10 @@ common base
     -funbox-strict-fields
   build-depends:
       base >=4.12 && <5
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , cereal ^>=0.5
     , haskoin-core >=1.0.0 && <1.2
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , unordered-containers ^>=0.2
 
 library
@@ -62,7 +62,7 @@ library
 
   build-depends:
       attoparsec >=0.13 && <0.15
-    , containers ^>=0.6
+    , containers >=0.6 && <0.8
     , transformers >=0.5 && <0.7
     , vector >=0.12.1.2 && <0.14
 
@@ -85,6 +85,6 @@ test-suite bitcoin-scripting-tests
 
   build-depends:
       bitcoin-scripting
-    , tasty >=1.0 && <1.5
+    , tasty >=1.0 && <1.6
     , tasty-hunit >=0.9 && <0.11
-    , tasty-quickcheck >=0.8.1 && <0.11
+    , tasty-quickcheck >=0.8.1 && <0.12


### PR DESCRIPTION
This PR bumps the upper constraints on some of the hackage dependencies, building against stackage LTS 23.X