### PR TITLE
bump cabal bound for haskoin-core

### DIFF
--- a/bitcoin-scripting.cabal
+++ b/bitcoin-scripting.cabal
@@ -31,7 +31,7 @@ common base
       base >=4.12 && <5
     , bytestring >=0.10 && <0.13
     , cereal ^>=0.5
-    , haskoin-core >=1.0.0 && <1.2
+    , haskoin-core >=1.0.0 && <1.3
     , text >=1.2 && <2.2
     , unordered-containers ^>=0.2
 


### PR DESCRIPTION
This PR bumps the upper bound for haskoin-core, allowing the package to build and test against stackage LTS 24.1